### PR TITLE
テンプレート機能を利用したときに、一番最後の行に日本語(ひらがな)を入力しようとすると文字が増殖するバグを修正

### DIFF
--- a/src/ui/insertion/chrome-insertion.ts
+++ b/src/ui/insertion/chrome-insertion.ts
@@ -30,7 +30,7 @@ export class ChromeInsertion extends AbstractInsertion {
             const range = selection.getRangeAt(0);
             range.deleteContents();
 
-            const node = document.createElement('div');
+            const node = document.createElement('span');
             node.style.whiteSpace = 'pre';
             node.innerHTML = DOMPurify.sanitize(text);
             range.insertNode(node);

--- a/src/ui/insertion/firefox-insertion.ts
+++ b/src/ui/insertion/firefox-insertion.ts
@@ -39,7 +39,7 @@ export class FirefoxInsertion extends AbstractInsertion {
             const range = selection.getRangeAt(0);
             range.deleteContents();
 
-            const node = document.createElement('div');
+            const node = document.createElement('span');
             node.style.whiteSpace = 'pre';
             node.innerHTML = DOMPurify.sanitize(text);
             range.insertNode(node);


### PR DESCRIPTION
## 🏁 Outline
- バグ修正のために挿入するタグを div から span に変更。

## 📝 Description
- テンプレート機能を利用したときに、一番最後の行に日本語(ひらがな)を入力しようとすると文字が増殖したり、文字が消えたりすることがある。半角英数字であれば発生しない。