### PR TITLE
Garoon に Plane Text の予定を貼り付けられるようにする

### DIFF
--- a/src/command/command-factory.ts
+++ b/src/command/command-factory.ts
@@ -11,6 +11,7 @@ import { TodayCommand } from './insert-schedule/today-command';
 import { TomorrowCommand } from './insert-schedule/tomorrow-command';
 import { YesterdayCommand } from './insert-schedule/yesterday-command';
 import { MarkdownCommand } from './markdown-command';
+import { PlaneTextCommand } from './plane-text-command';
 import { SettingsCommand } from './settings-command';
 import { UpdateMyGroupCommand } from './update-my-group-command';
 
@@ -41,6 +42,8 @@ export class CommandFactory implements Factory<CreateArgs, Command> {
                 return new HtmlCommand();
             case CONTEXT_MENU_ID.MARKDOWN:
                 return new MarkdownCommand();
+            case CONTEXT_MENU_ID.PLANE_TEXT:
+                return new PlaneTextCommand();
             case CONTEXT_MENU_ID.MY_GROUP:
                 return new UpdateMyGroupCommand(tab);
             case CONTEXT_MENU_ID.SETTINGS:

--- a/src/command/plane-text-command.ts
+++ b/src/command/plane-text-command.ts
@@ -1,0 +1,8 @@
+import { setSyntax } from '../storage';
+import { AbstractCommand } from './abstract-command';
+
+export class PlaneTextCommand extends AbstractCommand {
+    async execute() {
+        await setSyntax('planeText');
+    }
+}

--- a/src/context-menu/__test__/context-menu-builder.test.ts
+++ b/src/context-menu/__test__/context-menu-builder.test.ts
@@ -42,6 +42,7 @@ describe('ContextMenuBuilder', () => {
             createItem(CONTEXT_MENU_ID.SETTINGS, '設定', 'normal', {}),
             createItem(CONTEXT_MENU_ID.HTML, 'HTML', 'radio', { checked: true }),
             createItem(CONTEXT_MENU_ID.MARKDOWN, 'Markdown', 'radio', { checked: false }),
+            createItem(CONTEXT_MENU_ID.PLANE_TEXT, 'Plane Text', 'radio', { checked: false }),
             createItem(CONTEXT_MENU_ID.MYSELF, '自分', 'normal', {}),
             createItem(MY_GROUP_ID, 'Myグループ', 'normal', {}),
         ];
@@ -57,6 +58,7 @@ describe('ContextMenuBuilder', () => {
             .addSettings()
             .addHtml({ checked: true })
             .addMarkdown({ checked: false })
+            .addPlaneText({ checked: false })
             .addMyself()
             .addMenuItem(MY_GROUP_ID, 'Myグループ', 'normal', { parentId: CONTEXT_MENU_ID.ROOT })
             .build();

--- a/src/context-menu/context-menu-builder.ts
+++ b/src/context-menu/context-menu-builder.ts
@@ -26,6 +26,7 @@ export const CONTEXT_MENU_ID = {
     SETTINGS: 'settings',
     HTML: 'html',
     MARKDOWN: 'markdown',
+    PLANE_TEXT: 'planeText',
     MYSELF: 'myself',
 } as const;
 
@@ -113,6 +114,10 @@ export class ContextMenuBuilder {
 
     addMarkdown({ checked = false }) {
         return this.addMenuItem(CONTEXT_MENU_ID.MARKDOWN, 'Markdown', 'radio', { checked });
+    }
+
+    addPlaneText({ checked = false }) {
+        return this.addMenuItem(CONTEXT_MENU_ID.PLANE_TEXT, 'Plane Text', 'radio', { checked });
     }
 
     build() {

--- a/src/context-menu/operation.ts
+++ b/src/context-menu/operation.ts
@@ -32,6 +32,7 @@ export const buildContextMenu = async () => {
         const syntax = await getSyntax();
         builder.addHtml({ checked: syntax === 'html' });
         builder.addMarkdown({ checked: syntax === 'markdown' });
+        builder.addPlaneText({ checked: syntax === 'planeText' });
     }
 
     if (useMyGroup) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -26,6 +26,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     const syntaxInput = document.querySelector('#syntax');
     const htmlInput = document.querySelector('#html');
     const markdownInput = document.querySelector('#markdown');
+    const planeTextInput = document.querySelector('#plane-text');
     const alldayEventsShownInput = document.querySelector('#allday-events-shown');
     const useMyGroupInput = document.querySelector('#use-my-group');
     const templateTextarea = document.querySelector('.template-setting__textarea');
@@ -40,6 +41,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     assert(isInputElement(syntaxInput));
     assert(isInputElement(htmlInput));
     assert(isInputElement(markdownInput));
+    assert(isInputElement(planeTextInput));
     assert(isInputElement(alldayEventsShownInput));
     assert(isInputElement(useMyGroupInput));
     assert(isTextareaElement(templateTextarea));
@@ -60,6 +62,7 @@ window.addEventListener('DOMContentLoaded', async () => {
         const syntax = await getSyntax();
         htmlInput.checked = syntax === 'html';
         markdownInput.checked = syntax === 'markdown';
+        planeTextInput.checked = syntax === 'planeText';
     };
 
     const saveContextMenuDisplayed = async () => {
@@ -79,7 +82,15 @@ window.addEventListener('DOMContentLoaded', async () => {
         saveButton.disabled = true;
         saveButton.classList.add('saving');
         await saveContextMenuDisplayed();
-        await setSyntax(htmlInput.checked ? 'html' : 'markdown');
+
+        if (htmlInput.checked) {
+            await setSyntax('html');
+        } else if (markdownInput.checked) {
+            await setSyntax('markdown');
+        } else if (planeTextInput.checked) {
+            await setSyntax('planeText');
+        }
+
         await setAllDayEventsIncluded(alldayEventsShownInput.checked);
         await setToUseMyGroup(useMyGroupInput.checked);
         await setTemplateText(templateTextarea.value);

--- a/src/syntax/html-syntax-generator.ts
+++ b/src/syntax/html-syntax-generator.ts
@@ -56,7 +56,7 @@ export class HtmlSyntaxGenerator extends AbstractSyntaxGenerator {
     }
 
     private createMembers(members: Member[]) {
-        return `<span style="color: #607d8b;">${members
+        return `<span style="color: #607d8b;">: ${members
             .map((member) => member.name)
             .join(', ')
             .replace(/, $/, '')}</span>`;

--- a/src/syntax/markdown-syntax-generator.ts
+++ b/src/syntax/markdown-syntax-generator.ts
@@ -54,7 +54,7 @@ export class MarkdownSyntaxGenerator extends AbstractSyntaxGenerator {
     }
 
     private createMembers(members: Member[]) {
-        return `<span style="color: #607d8b;">${members
+        return `<span style="color: #607d8b;">: ${members
             .map((member) => member.name)
             .join(', ')
             .replace(/, $/, '')}</span>`;

--- a/src/syntax/plane-text-syntax-generator.ts
+++ b/src/syntax/plane-text-syntax-generator.ts
@@ -49,9 +49,9 @@ export class PlaneTextSyntaxGenerator extends AbstractSyntaxGenerator {
     }
 
     private createMembers(members: Member[]) {
-        return members
+        return `: ${members
             .map((member) => member.name)
             .join(', ')
-            .replace(/, $/, '');
+            .replace(/, $/, '')}`;
     }
 }

--- a/src/syntax/plane-text-syntax-generator.ts
+++ b/src/syntax/plane-text-syntax-generator.ts
@@ -1,0 +1,57 @@
+import { Member, MyGroupEvent, ScheduleEvent } from '../events/schedule';
+import { DateTime } from '../util/date-time';
+import { AbstractSyntaxGenerator } from './abstract-syntax-generator';
+
+export class PlaneTextSyntaxGenerator extends AbstractSyntaxGenerator {
+    createTitle(dateTime: DateTime) {
+        return `[ ${dateTime.format('YYYY-MM-DD')} の予定 ]`;
+    }
+
+    createEvent(_: string, event: ScheduleEvent | MyGroupEvent) {
+        const timeRange = this.createTimeRange(event);
+        const subject = event.subject;
+        const eventMenu = event.eventMenu === '' ? null : this.createEventMenu(event.eventMenu);
+
+        if (eventMenu === null) {
+            return this.isMyGroupEvent(event)
+                ? `${timeRange} ${subject} ${this.createMembers(event.members)}`
+                : `${timeRange} ${subject}`;
+        }
+
+        return this.isMyGroupEvent(event)
+            ? `${timeRange} ${eventMenu} ${subject} ${this.createMembers(event.members)}`
+            : `${timeRange} ${eventMenu} ${subject}`;
+    }
+
+    createEvents(domain: string, events: ScheduleEvent[]) {
+        return events
+            .map((event) => `${this.createEvent(domain, event)}${this.getNewLine()}`)
+            .join('')
+            .replace(new RegExp(`${this.getNewLine()}$`), '');
+    }
+
+    getNewLine() {
+        return '\n';
+    }
+
+    private createTimeRange(event: ScheduleEvent | MyGroupEvent) {
+        if (event.isAllDay) {
+            return this.createEventMenu('終日');
+        }
+
+        const start = event.isContinuingFromYesterday ? '(前日)' : event.startTime.format('HH:mm');
+        const end = event.isContinuingToTomorrow ? '(翌日)' : event.endTime.format('HH:mm');
+        return `${start}-${end}`;
+    }
+
+    private createEventMenu(eventMenu: string) {
+        return `[${eventMenu}]`;
+    }
+
+    private createMembers(members: Member[]) {
+        return members
+            .map((member) => member.name)
+            .join(', ')
+            .replace(/, $/, '');
+    }
+}

--- a/src/syntax/syntax-generator-factory.ts
+++ b/src/syntax/syntax-generator-factory.ts
@@ -2,6 +2,7 @@ import { Factory } from '../util/factory';
 import { SyntaxGenerator } from './abstract-syntax-generator';
 import { HtmlSyntaxGenerator } from './html-syntax-generator';
 import { MarkdownSyntaxGenerator } from './markdown-syntax-generator';
+import { PlaneTextSyntaxGenerator } from './plane-text-syntax-generator';
 import { Syntax } from './types';
 
 export class SyntaxGeneratorFactory implements Factory<Syntax, SyntaxGenerator> {
@@ -11,6 +12,8 @@ export class SyntaxGeneratorFactory implements Factory<Syntax, SyntaxGenerator> 
                 return new HtmlSyntaxGenerator();
             case 'markdown':
                 return new MarkdownSyntaxGenerator();
+            case 'planeText':
+                return new PlaneTextSyntaxGenerator();
             default:
                 throw new Error('Syntax is not implemented.');
         }

--- a/src/syntax/types.ts
+++ b/src/syntax/types.ts
@@ -1,1 +1,1 @@
-export type Syntax = 'html' | 'markdown';
+export type Syntax = 'html' | 'markdown' | 'planeText';

--- a/static/chrome/manifest.json
+++ b/static/chrome/manifest.json
@@ -11,12 +11,12 @@
     },
     "permissions": ["background", "contextMenus", "storage"],
     "host_permissions": [
-        "https://*.cybozu.com/k/*",
-        "https://*.cybozu-dev.com/k/*",
-        "https://*.kintone.com/k/*",
-        "https://*.kintone-dev.com/k/*",
-        "https://*.cybozu.cn/k/*",
-        "https://*.cybozu-dev.cn/k/*"
+        "https://*.cybozu.com/*",
+        "https://*.cybozu-dev.com/*",
+        "https://*.kintone.com/*",
+        "https://*.kintone-dev.com/*",
+        "https://*.cybozu.cn/*",
+        "https://*.cybozu-dev.cn/*"
     ],
     "options_ui": {
         "page": "../options.html"
@@ -28,12 +28,12 @@
     "content_scripts": [
         {
             "matches": [
-                "https://*.cybozu.com/k/*",
-                "https://*.cybozu-dev.com/k/*",
-                "https://*.kintone.com/k/*",
-                "https://*.kintone-dev.com/k/*",
-                "https://*.cybozu.cn/k/*",
-                "https://*.cybozu-dev.cn/k/*"
+                "https://*.cybozu.com/*",
+                "https://*.cybozu-dev.com/*",
+                "https://*.kintone.com/*",
+                "https://*.kintone-dev.com/*",
+                "https://*.cybozu.cn/*",
+                "https://*.cybozu-dev.cn/*"
             ],
             "js": ["../../src/content-script.ts"],
             "run_at": "document_end"

--- a/static/firefox/manifest.json
+++ b/static/firefox/manifest.json
@@ -17,12 +17,12 @@
     "permissions": [
         "contextMenus",
         "storage",
-        "https://*.cybozu.com/k/*",
-        "https://*.cybozu-dev.com/k/*",
-        "https://*.kintone.com/k/*",
-        "https://*.kintone-dev.com/k/*",
-        "https://*.cybozu.cn/k/*",
-        "https://*.cybozu-dev.cn/k/*"
+        "https://*.cybozu.com/*",
+        "https://*.cybozu-dev.com/*",
+        "https://*.kintone.com/*",
+        "https://*.kintone-dev.com/*",
+        "https://*.cybozu.cn/*",
+        "https://*.cybozu-dev.cn/*"
     ],
     "options_ui": {
         "page": "../options.html"
@@ -33,12 +33,12 @@
     "content_scripts": [
         {
             "matches": [
-                "https://*.cybozu.com/k/*",
-                "https://*.cybozu-dev.com/k/*",
-                "https://*.kintone.com/k/*",
-                "https://*.kintone-dev.com/k/*",
-                "https://*.cybozu.cn/k/*",
-                "https://*.cybozu-dev.cn/k/*"
+                "https://*.cybozu.com/*",
+                "https://*.cybozu-dev.com/*",
+                "https://*.kintone.com/*",
+                "https://*.kintone-dev.com/*",
+                "https://*.cybozu.cn/*",
+                "https://*.cybozu-dev.cn/*"
             ],
             "js": ["../../src/content-script.ts"],
             "run_at": "document_end"

--- a/static/options.html
+++ b/static/options.html
@@ -63,6 +63,10 @@
                     <input id="markdown" class="radio" type="radio" name="syntax-setting" />
                     <span class="radio-text">Markdown</span>
                 </label>
+                <label class="radio-label">
+                    <input id="plane-text" class="radio" type="radio" name="syntax-setting" />
+                    <span class="radio-text">Plane Text</span>
+                </label>
             </fieldset>
             <fieldset id="allday-events-shown-setting" class="group">
                 <legend class="group__title">終日予定の表示</legend>


### PR DESCRIPTION
## 🏁 Outline

- Garoon に Plane Text の予定を貼り付け可能にする

## 🔗 References

- https://github.com/SchedulePicker/SchedulePicker3/issues/28
- https://github.com/SchedulePicker/SchedulePicker3/issues/27

## 📝 Description

- Garoon, Office, Mailwise でも使用可能にした。範囲を拡大したことでストアでブロックされた場合は kintone と Garoon に絞る。
- リッチテキストエディタがない箇所に予定を貼り付けられるようにするために「Plane Text」を用意
- Myグループの予定を取得したときに参加者と予定の境目が分かりにくかったので間に「:」を追加